### PR TITLE
fix: Downgrade GSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.intellectualsites.paster:Paster:1.1.3")
+    implementation("com.intellectualsites.paster:Paster:1.1.4")
 }
 ```
 You need to shade Paster into your software by either using maven shade or gradle shadow.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ configurations.all {
 }
 
 group = "com.intellectualsites.paster"
-version = "1.1.4-SNAPSHOT"
+version = "1.1.4"
 
 repositories {
     mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Minecraft expectations
-gson = "2.8.8" # Version set by Minecraft
-guava = "31.0.1-jre" # Version set by Minecraft
+gson = "2.8.0" # Version set by Minecraft 1.15.2
+guava = "21.0" # Version set by Minecraft
 
 # Annotations
 findbugs = "3.0.2"

--- a/src/main/java/com/intellectualsites/paster/IncendoPaster.java
+++ b/src/main/java/com/intellectualsites/paster/IncendoPaster.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("unused")
 public class IncendoPaster {
 
     /**
@@ -156,7 +157,7 @@ public class IncendoPaster {
         } catch (Throwable throwable) {
             throw new IOException(String.format("Failed to upload files: %s", throwable.getMessage()), throwable);
         }
-        final JsonObject jsonObject = JsonParser.parseString(rawResponse).getAsJsonObject();
+        final JsonObject jsonObject = new JsonParser().parse(rawResponse).getAsJsonObject();
 
         if (jsonObject.has("created")) {
             final String pasteId = jsonObject.get("paste_id").getAsString();


### PR DESCRIPTION
Otherwise the server NoSuchMethodError, becase JsonParser#parseString doesn't exist on 2.8.0

Don't squash merge, this will handle the entire release.
